### PR TITLE
Add .git-blame-ignore-revs file containing format commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# scalafmt
+af0dc3cc8635a1f5a7760bbdcc6259559d70c77a


### PR DESCRIPTION
Similar to pekko core, adds a `.git-blame-ignore-revs` which contains the hashes for the previous scalafmt commits.