### PR TITLE
Move required_pull_request_reviews to correct area

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,13 +19,12 @@ github:
     merge:   false
     rebase:  true
 
-  required_pull_request_reviews:
-    dismiss_stale_reviews: false
-    require_code_owner_reviews: false
-    required_approving_review_count: 1
-
   protected_branches:
-    main: { }
+    main:
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1
 
 notifications:
   commits:              commits@pekko.apache.org


### PR DESCRIPTION
This puts `required_pull_request_reviews` to correct area, currently its not doing anything