### PR TITLE
Update sbt-apache-sonatype and handle rename

### DIFF
--- a/project/AddMetaInfLicenseFiles.scala
+++ b/project/AddMetaInfLicenseFiles.scala
@@ -11,13 +11,13 @@ import sbt.AutoPlugin
 
 import sbt.Keys._
 import sbt._
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin.autoImport._
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin.autoImport._
 
 object AddMetaInfLicenseFiles extends AutoPlugin {
   override def trigger = allRequirements
 
-  override def requires = SonatypeApachePlugin
+  override def requires = ApacheSonatypePlugin
 
   override lazy val projectSettings = Seq(
     apacheSonatypeDisclaimerFile := Some((LocalRootProject / baseDirectory).value / "DISCLAIMER"))

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,7 +1,7 @@
 import org.apache.pekko.projections.Dependencies
 import sbtdynver.DynVerPlugin.autoImport._
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys._
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
@@ -12,7 +12,7 @@ object Common extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  override def requires = JvmPlugin && SonatypeApachePlugin && DynVerPlugin
+  override def requires = JvmPlugin && ApacheSonatypePlugin && DynVerPlugin
 
   override def globalSettings =
     Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
 
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.6")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.7")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
 
 // Documentation


### PR DESCRIPTION
Updates sbt-apache-sonatype. Note that this new version renames `SonatypeApachePlugin` to `ApacheSonatypePlugin` to be consistent with the project name.