### PR TITLE
Unwrap single string interpolation syntax

### DIFF
--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -69,7 +69,7 @@ trait CopyrightHeader extends AutoPlugin {
         case Some(currentText) if isLightbendCopyrighted(currentText) =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText) + NewLine * 2 + currentText
         case Some(currentText) =>
-          throw new IllegalStateException(s"Unable to detect copyright for header:[${currentText}]")
+          throw new IllegalStateException(s"Unable to detect copyright for header:[$currentText]")
         case None =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText)
       }


### PR DESCRIPTION
Unwraps single string interpolation i.e. `s"${something}"` into `s"$something"`. Make sure to do a rebase merge of this PR because I need to add its commit to `.git-blame-ignore-revs`