### PR TITLE
Add protected tags to .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -6,6 +6,8 @@ github:
   labels:
     - pekko
 
+  protected_tags:
+    - "v*.*.*"
   features:
     # Enable wiki for documentation
     wiki: false


### PR DESCRIPTION
Currently the protected tags was setup manually however there is now official support for this in `.asf.yaml` (see https://issues.apache.org/jira/browse/INFRA-24644?focusedCommentId=17728711&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17728711).

Resolves: https://github.com/apache/incubator-pekko-projection/issues/51. The issue also states why not to merge for now.

