### PR TITLE
Submit dependabot dependency graph to Github

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -5,7 +5,7 @@ github:
   homepage: https://pekko.apache.org/
   labels:
     - pekko
-  
+
   features:
     # Enable wiki for documentation
     wiki: false

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,12 @@
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - main # default branch of the project
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: scalacenter/sbt-dependency-submission@v2


### PR DESCRIPTION
This PR uses scala centers official integration of sbt with github's dependabot (see https://github.com/scalacenter/sbt-dependency-submission) to submit any potential security vulnerabilities. This is a more practical solution compared to https://github.com/apache/incubator-pekko/pull/289 especially in regards to getting it ready for release candidate.